### PR TITLE
feat: Add a federation example which uses the `cofide-trust-zone-server` and the Terraform provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cofide.yaml
 *.sha256
 generated/*
 terraform.tfstate
+terraform.tfstate.backup
 terraform.tfvars
 .terraform
 *.env

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Validates the deployment with federated ping-pong.
 ./federated-cofidectl.sh
 ```
 
-A corresponding script that uses the Cofide Terraform provider in conjunction with cofidectl can be run using:
+A corresponding script that uses cofidectl and terraform-provide-cofide, with the Cofide trust zone server can be run using:
 
 ```sh
 ./single-trust-zone-cofidectl-tf.sh

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Validates the deployment with federated ping-pong.
 ./federated-cofidectl.sh
 ```
 
+A corresponding script that uses the Cofide Terraform provider in conjunction with cofidectl can be run using:
+
+```sh
+./single-trust-zone-cofidectl-tf.sh
+```
+
 ## Multi-mesh with cofidectl
 
 Run this script to deploy two federated trust zones in Kind clusters with Istio using cofidectl.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Validates the deployment with ping-pong.
 ./single-trust-zone-cofidectl.sh
 ```
 
+A corresponding script that uses cofidectl and [terraform-provider-cofide](https://registry.terraform.io/providers/cofide/cofide/latest/docs) can be run using:
+
+```sh
+./single-trust-zone-cofidectl-tf.sh
+```
+
 ## Federated trust zones with cofidectl
 
 Run this script to deploy two federated trust zones in Kind clusters using cofidectl.
@@ -93,10 +99,10 @@ Validates the deployment with federated ping-pong.
 ./federated-cofidectl.sh
 ```
 
-A corresponding script that uses cofidectl and terraform-provide-cofide, with the Cofide trust zone server can be run using:
+A corresponding script that uses cofidectl and [terraform-provider-cofide](https://registry.terraform.io/providers/cofide/cofide/latest/docs), with the Cofide trust zone server can be run using:
 
 ```sh
-./single-trust-zone-cofidectl-tf.sh
+./federated-cofidectl-tf.sh
 ```
 
 ## Multi-mesh with cofidectl

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -95,16 +95,15 @@ export TF_VAR_trust_domain_1="${WORKLOAD_TRUST_DOMAIN_1}"
 export TF_VAR_cluster_1_name="${WORKLOAD_K8S_CLUSTER_NAME_1}"
 export TF_VAR_cluster_1_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_1}"
 export TF_VAR_cluster_1_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_1}.yaml)"
-export TF_VAR_attestation_policy_1_name="${NAMESPACE}-ns-${WORKLOAD_TRUST_ZONE_1}"
-export TF_VAR_attestation_policy_1_namespace="${NAMESPACE}"
+
+export TF_VAR_attestation_policy_name="${NAMESPACE}-ns-${UNIQUE_ID}"
+export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
 
 export TF_VAR_trust_zone_2_name="${WORKLOAD_TRUST_ZONE_2}"
 export TF_VAR_trust_domain_2="${WORKLOAD_TRUST_DOMAIN_2}"
 export TF_VAR_cluster_2_name="${WORKLOAD_K8S_CLUSTER_NAME_2}"
 export TF_VAR_cluster_2_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_2}.yaml)"
 export TF_VAR_cluster_2_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_2}"
-export TF_VAR_attestation_policy_name="${NAMESPACE}-ns-${UNIQUE_ID}"
-export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
 
 terraform -chdir=./terraform/federated init -input=false -backend=false
 

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# This script creates a pair of kind clusters and defines trust zones,
+# clusters, an attestation policy, bindings and federations in the staging
+# Connect using cofidectl and terraform-provider-cofide.
+# It then runs a ping-pong test between the trust zones.
+
+# Prerequisites: ./prerequisites.sh
+
+source config.env
+
+## Deploy workload cluster
+
+export REGISTRY=010438484483.dkr.ecr.eu-west-1.amazonaws.com
+export REPOSITORY=cofide/trust-zone-server
+export TAG=v1.10.9
+export CONNECT_URL=$CONNECT_URL
+export CONNECT_TRUST_DOMAIN=$CONNECT_TRUST_DOMAIN
+
+BUNDLE_ID=$(echo $CONNECT_TRUST_DOMAIN | cut -d '.' -f 1)
+export CONNECT_BUNDLE_ENDPOINT_URL="https://$CONNECT_BUNDLE_HOST/$BUNDLE_ID/bundle"
+
+# Generate unique ID for cluster, trust zone & trust domain disambiguation
+UNIQUE_ID=$(uuidgen | head -c 8 | tr A-Z a-z)
+
+WORKLOAD_K8S_CLUSTER_NAME_1="workload-${UNIQUE_ID}-1"
+WORKLOAD_K8S_CLUSTER_CONTEXT_1="kind-workload-${UNIQUE_ID}-1"
+# Trust zones must be unique within a single Cofide Connect service.
+WORKLOAD_TRUST_ZONE_1="${UNIQUE_ID}-1"
+# Trust domains must currently be globally unique due to a shared S3 bucket for hosting bundles.
+WORKLOAD_TRUST_DOMAIN_1="${UNIQUE_ID}-1.test"
+
+export CLUSTER_NAME=$WORKLOAD_K8S_CLUSTER_NAME_1
+export TRUST_DOMAIN=$WORKLOAD_TRUST_DOMAIN_1
+
+envsubst < templates/trust-zone-server-values.yaml > generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_1}.yaml
+
+WORKLOAD_K8S_CLUSTER_NAME_2="workload-${UNIQUE_ID}-2"
+WORKLOAD_K8S_CLUSTER_CONTEXT_2="kind-workload-${UNIQUE_ID}-2"
+# Trust zones must be unique within a single Cofide Connect service.
+WORKLOAD_TRUST_ZONE_2="${UNIQUE_ID}-2"
+# Trust domains must currently be globally unique due to a shared S3 bucket for hosting bundles.
+WORKLOAD_TRUST_DOMAIN_2="${UNIQUE_ID}-2.test"
+
+export CLUSTER_NAME=$WORKLOAD_K8S_CLUSTER_NAME_2
+export TRUST_DOMAIN=$WORKLOAD_TRUST_DOMAIN_2
+
+envsubst < templates/trust-zone-server-values.yaml > generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_2}.yaml
+
+kind delete cluster --name $WORKLOAD_K8S_CLUSTER_NAME_1
+kind delete cluster --name $WORKLOAD_K8S_CLUSTER_NAME_2
+
+# Patch in host Docker config in order to enable pulling images
+# to the Kind cluster. This envsubst approach is required as Kind does
+# not support ~ or $HOME directly in the extraMounts attribute of the config
+# https://github.com/kubernetes-sigs/kind/issues/3642
+export PATH_TO_HOST_DOCKER_CREDENTIALS=$HOME/.docker/config.json
+envsubst < templates/kind_workload_config_template.yaml > generated/kind_workload_config.yaml
+kind create cluster --name $WORKLOAD_K8S_CLUSTER_NAME_1 --config generated/kind_workload_config.yaml
+kind create cluster --name $WORKLOAD_K8S_CLUSTER_NAME_2 --config generated/kind_workload_config.yaml
+
+# Applies the RBAC needed by the trust zone server in each Kind cluster.
+kubectl apply -f templates/trust-zone-server-rbac.yaml --context $WORKLOAD_K8S_CLUSTER_CONTEXT_1
+kubectl apply -f templates/trust-zone-server-rbac.yaml --context $WORKLOAD_K8S_CLUSTER_CONTEXT_2
+
+## Deploy workload identity infrastructure using cofidectl and terraform-provider-cofide
+
+rm -f cofide.yaml
+cofidectl connect init \
+  --connect-url $CONNECT_URL \
+  --connect-trust-domain $CONNECT_TRUST_DOMAIN \
+  --connect-bundle-host $CONNECT_BUNDLE_HOST \
+  --authorization-domain $AUTHORIZATION_DOMAIN \
+  --authorization-client-id $AUTHORIZATION_CLIENT_ID \
+  --connect-datasource
+
+set +x
+ACCESS_TOKEN=$(grep 'cofide_access_token' ~/.cofide/credentials | cut -d'=' -f2)
+if [ -z "${ACCESS_TOKEN}" ]; then
+  echo "ERROR: Failed to get access token" >&2
+  exit 1
+fi
+export COFIDE_API_TOKEN="${ACCESS_TOKEN}"
+set -x
+
+export COFIDE_CONNECT_URL="${CONNECT_URL}"
+
+# Set this to true if running against a local instance of Connect.
+export COFIDE_INSECURE_SKIP_VERIFY=true
+
+export TF_VAR_trust_zone_1_name="${WORKLOAD_TRUST_ZONE_1}"
+export TF_VAR_trust_domain_1="${WORKLOAD_TRUST_DOMAIN_1}"
+export TF_VAR_cluster_1_name="${WORKLOAD_K8S_CLUSTER_NAME_1}"
+export TF_VAR_cluster_1_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_1}"
+export TF_VAR_cluster_1_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_1}.yaml)"
+export TF_VAR_attestation_policy_1_name="${NAMESPACE-ns-$WORKLOAD_TRUST_ZONE_1}"
+export TF_VAR_attestation_policy_1_namespace="${NAMESPACE}"
+
+export TF_VAR_trust_zone_2_name="${WORKLOAD_TRUST_ZONE_2}"
+export TF_VAR_trust_domain_2="${WORKLOAD_TRUST_DOMAIN_2}"
+export TF_VAR_cluster_2_name="${WORKLOAD_K8S_CLUSTER_NAME_2}"
+export TF_VAR_cluster_2_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_2}.yaml)"
+export TF_VAR_cluster_2_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_2}"
+export TF_VAR_attestation_policy_name="${NAMESPACE-ns-$UNIQUE_ID}"
+export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
+
+terraform -chdir=./terraform/federated init -input=false -backend=false
+
+## Ensures that any resources from previous runs have been deleted first.
+terraform -chdir=./terraform/federated destroy -input=false -auto-approve
+terraform -chdir=./terraform/federated apply -input=false -auto-approve
+
+cofidectl up --trust-zone $WORKLOAD_TRUST_ZONE_1 --trust-zone $WORKLOAD_TRUST_ZONE_2
+
+## Validate the deployment using ping-pong demo
+
+kubectl --context $WORKLOAD_K8S_CLUSTER_CONTEXT_1 create namespace $NAMESPACE
+kubectl --context $WORKLOAD_K8S_CLUSTER_CONTEXT_2 create namespace $NAMESPACE
+
+SERVER_CTX=$WORKLOAD_K8S_CLUSTER_CONTEXT_1
+CLIENT_CTX=$WORKLOAD_K8S_CLUSTER_CONTEXT_2
+
+export IMAGE_TAG=v0.1.10 # Version of cofide-demos to use
+COFIDE_DEMOS_BRANCH="https://raw.githubusercontent.com/cofide/cofide-demos/refs/tags/$IMAGE_TAG"
+
+SERVER_MANIFEST="$COFIDE_DEMOS_BRANCH/workloads/ping-pong/ping-pong-server/deploy.yaml"
+export PING_PONG_SERVER_SERVICE_PORT=8443
+if ! curl --fail $SERVER_MANIFEST | envsubst | kubectl apply -n "$NAMESPACE" --context "$SERVER_CTX" -f -; then
+  echo "Error: Server deployment failed" >&2
+  exit 1
+fi
+echo "Server deployment complete"
+
+echo "Discovering server IP..."
+kubectl --context "$SERVER_CTX" wait --for=jsonpath="{.status.loadBalancer.ingress[0].ip}" service/ping-pong-server -n $NAMESPACE --timeout=60s
+export PING_PONG_SERVER_SERVICE_HOST=$(kubectl --context "$SERVER_CTX" get service ping-pong-server -n $NAMESPACE -o "jsonpath={.status.loadBalancer.ingress[0].ip}")
+echo "Server is $PING_PONG_SERVER_SERVICE_HOST"
+
+CLIENT_MANIFEST="$COFIDE_DEMOS_BRANCH/workloads/ping-pong/ping-pong-client/deploy.yaml"
+if ! curl --fail $CLIENT_MANIFEST | envsubst | kubectl apply --context "$CLIENT_CTX" -n "$NAMESPACE" -f -; then
+  echo "Error: client deployment failed" >&2
+  exit 1
+fi
+echo "Client deployment complete"
+
+kubectl --context $CLIENT_CTX wait -n $NAMESPACE --for=condition=Available --timeout 120s deployments/ping-pong-client
+kubectl --context $CLIENT_CTX logs -n $NAMESPACE deployments/ping-pong-client -f

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -95,7 +95,7 @@ export TF_VAR_trust_domain_1="${WORKLOAD_TRUST_DOMAIN_1}"
 export TF_VAR_cluster_1_name="${WORKLOAD_K8S_CLUSTER_NAME_1}"
 export TF_VAR_cluster_1_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_1}"
 export TF_VAR_cluster_1_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_1}.yaml)"
-export TF_VAR_attestation_policy_1_name="${NAMESPACE-ns-$WORKLOAD_TRUST_ZONE_1}"
+export TF_VAR_attestation_policy_1_name="${NAMESPACE}-ns-${WORKLOAD_TRUST_ZONE_1}"
 export TF_VAR_attestation_policy_1_namespace="${NAMESPACE}"
 
 export TF_VAR_trust_zone_2_name="${WORKLOAD_TRUST_ZONE_2}"
@@ -103,7 +103,7 @@ export TF_VAR_trust_domain_2="${WORKLOAD_TRUST_DOMAIN_2}"
 export TF_VAR_cluster_2_name="${WORKLOAD_K8S_CLUSTER_NAME_2}"
 export TF_VAR_cluster_2_extra_helm_values="$(realpath generated/trust-zone-server-values-${WORKLOAD_TRUST_ZONE_2}.yaml)"
 export TF_VAR_cluster_2_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT_2}"
-export TF_VAR_attestation_policy_name="${NAMESPACE-ns-$UNIQUE_ID}"
+export TF_VAR_attestation_policy_name="${NAMESPACE}-ns-${UNIQUE_ID}"
 export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
 
 terraform -chdir=./terraform/federated init -input=false -backend=false

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -88,7 +88,7 @@ set -x
 export COFIDE_CONNECT_URL="${CONNECT_URL}"
 
 # Set this to true if running against a local instance of Connect.
-export COFIDE_INSECURE_SKIP_VERIFY=true
+export COFIDE_INSECURE_SKIP_VERIFY=false
 
 export TF_VAR_trust_zone_1_name="${WORKLOAD_TRUST_ZONE_1}"
 export TF_VAR_trust_domain_1="${WORKLOAD_TRUST_DOMAIN_1}"

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -16,8 +16,8 @@ source config.env
 export REGISTRY=010438484483.dkr.ecr.eu-west-1.amazonaws.com
 export REPOSITORY=cofide/trust-zone-server
 export TAG=v1.10.9
-export CONNECT_URL=$CONNECT_URL
-export CONNECT_TRUST_DOMAIN=$CONNECT_TRUST_DOMAIN
+export CONNECT_URL
+export CONNECT_TRUST_DOMAIN
 
 BUNDLE_ID=$(echo $CONNECT_TRUST_DOMAIN | cut -d '.' -f 1)
 export CONNECT_BUNDLE_ENDPOINT_URL="https://$CONNECT_BUNDLE_HOST/$BUNDLE_ID/bundle"

--- a/federated-cofidectl-tf.sh
+++ b/federated-cofidectl-tf.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # This script creates a pair of kind clusters and defines trust zones,
 # clusters, an attestation policy, bindings and federations in the staging
 # Connect using cofidectl and terraform-provider-cofide.
-# It then runs a ping-pong test between the trust zones.
+# It then runs a ping-pong test between the trust zones, each using the Cofide trust zone server.
 
 # Prerequisites: ./prerequisites.sh
 

--- a/federated-cofidectl.sh
+++ b/federated-cofidectl.sh
@@ -122,5 +122,5 @@ if ! curl --fail $CLIENT_MANIFEST | envsubst | kubectl apply --context "$CLIENT_
 fi
 echo "Client deployment complete"
 
-kubectl --context $CLIENT_CTX wait -n $NAMESPACE --for=condition=Available --timeout 60s deployments/ping-pong-client
+kubectl --context $CLIENT_CTX wait -n $NAMESPACE --for=condition=Available --timeout 120s deployments/ping-pong-client
 kubectl --context $CLIENT_CTX logs -n $NAMESPACE deployments/ping-pong-client -f

--- a/single-trust-zone-cofidectl-tf.sh
+++ b/single-trust-zone-cofidectl-tf.sh
@@ -55,7 +55,7 @@ set -x
 export COFIDE_CONNECT_URL="${CONNECT_URL}"
 
 # Set this to true if running against a local instance of Connect.
-export COFIDE_INSECURE_SKIP_VERIFY=true
+export COFIDE_INSECURE_SKIP_VERIFY=false
 
 export TF_VAR_trust_zone_name="${WORKLOAD_TRUST_ZONE}"
 export TF_VAR_trust_domain="${WORKLOAD_TRUST_DOMAIN}"

--- a/single-trust-zone-cofidectl-tf.sh
+++ b/single-trust-zone-cofidectl-tf.sh
@@ -61,7 +61,7 @@ export TF_VAR_trust_zone_name="${WORKLOAD_TRUST_ZONE}"
 export TF_VAR_trust_domain="${WORKLOAD_TRUST_DOMAIN}"
 export TF_VAR_cluster_name="${WORKLOAD_K8S_CLUSTER_NAME}"
 export TF_VAR_cluster_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT}"
-export TF_VAR_attestation_policy_name="${NAMESPACE-ns-$WORKLOAD_TRUST_ZONE}"
+export TF_VAR_attestation_policy_name="${NAMESPACE}-ns-${WORKLOAD_TRUST_ZONE}"
 export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
 
 terraform -chdir=./terraform/single-trust-zone init -input=false -backend=false

--- a/single-trust-zone-cofidectl-tf.sh
+++ b/single-trust-zone-cofidectl-tf.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# This script creates a kind cluster and defines a trust zone, cluster,
+# attestation policy and binding in the staging Connect using cofidectl and terraform-provider-cofide.
+# It then runs a ping-pong test.
+
+# Prerequisites: ./prerequisites.sh
+
+source config.env
+
+## Deploy workload cluster
+
+# Generate unique ID for cluster, trust zone & trust domain disambiguation
+UNIQUE_ID=$(uuidgen | head -c 8 | tr A-Z a-z)
+
+WORKLOAD_K8S_CLUSTER_NAME="${WORKLOAD_K8S_CLUSTER_NAME:-workload-${UNIQUE_ID}}"
+WORKLOAD_K8S_CLUSTER_CONTEXT="${WORKLOAD_K8S_CLUSTER_CONTEXT:-kind-workload-${UNIQUE_ID}}"
+# Trust zones must be unique within a single Cofide Connect service.
+WORKLOAD_TRUST_ZONE=${WORKLOAD_TRUST_ZONE:-${UNIQUE_ID}}
+# Trust domains must currently be globally unique due to a shared S3 bucket for hosting bundles.
+WORKLOAD_TRUST_DOMAIN=${WORKLOAD_TRUST_DOMAIN:-${UNIQUE_ID}.test}
+
+kind delete cluster --name $WORKLOAD_K8S_CLUSTER_NAME
+
+# Patch in host Docker config in order to enable pulling images
+# to the Kind cluster. This envsubst approach is required as Kind does
+# not support ~ or $HOME directly in the extraMounts attribute of the config
+# https://github.com/kubernetes-sigs/kind/issues/3642
+export PATH_TO_HOST_DOCKER_CREDENTIALS=$HOME/.docker/config.json
+envsubst < templates/kind_workload_config_template.yaml > generated/kind_workload_config.yaml
+kind create cluster --name $WORKLOAD_K8S_CLUSTER_NAME --config generated/kind_workload_config.yaml
+
+## Deploy workload identity infrastructure using cofidectl and terraform-provider-cofide
+
+rm -f cofide.yaml
+cofidectl connect init \
+  --connect-url $CONNECT_URL \
+  --connect-trust-domain $CONNECT_TRUST_DOMAIN \
+  --connect-bundle-host $CONNECT_BUNDLE_HOST \
+  --authorization-domain $AUTHORIZATION_DOMAIN \
+  --authorization-client-id $AUTHORIZATION_CLIENT_ID \
+  --connect-datasource
+
+set +x
+ACCESS_TOKEN=$(grep 'cofide_access_token' ~/.cofide/credentials | cut -d'=' -f2)
+if [ -z "${ACCESS_TOKEN}" ]; then
+  echo "ERROR: Failed to get access token" >&2
+  exit 1
+fi
+export COFIDE_API_TOKEN="${ACCESS_TOKEN}"
+set -x
+
+export COFIDE_CONNECT_URL="${CONNECT_URL}"
+
+# Set this to true if running against a local instance of Connect.
+export COFIDE_INSECURE_SKIP_VERIFY=true
+
+export TF_VAR_trust_zone_name="${WORKLOAD_TRUST_ZONE}"
+export TF_VAR_trust_domain="${WORKLOAD_TRUST_DOMAIN}"
+export TF_VAR_cluster_name="${WORKLOAD_K8S_CLUSTER_NAME}"
+export TF_VAR_cluster_kubernetes_context="${WORKLOAD_K8S_CLUSTER_CONTEXT}"
+export TF_VAR_attestation_policy_name="${NAMESPACE-ns-$WORKLOAD_TRUST_ZONE}"
+export TF_VAR_attestation_policy_namespace="${NAMESPACE}"
+
+terraform -chdir=./terraform/single-trust-zone init -input=false -backend=false
+
+## Ensures that any resources from previous runs have been deleted first.
+terraform -chdir=./terraform/single-trust-zone destroy -input=false -auto-approve
+terraform -chdir=./terraform/single-trust-zone apply -input=false -auto-approve
+
+cofidectl up --trust-zone $WORKLOAD_TRUST_ZONE
+
+## Validate the deployment using ping-pong demo
+
+kubectl --context $WORKLOAD_K8S_CLUSTER_CONTEXT create namespace $NAMESPACE
+
+SERVER_CTX=$WORKLOAD_K8S_CLUSTER_CONTEXT
+CLIENT_CTX=$WORKLOAD_K8S_CLUSTER_CONTEXT
+
+export IMAGE_TAG=v0.1.10 # Version of cofide-demos to use
+COFIDE_DEMOS_BRANCH="https://raw.githubusercontent.com/cofide/cofide-demos/refs/tags/$IMAGE_TAG"
+
+SERVER_MANIFEST="$COFIDE_DEMOS_BRANCH/workloads/ping-pong/ping-pong-server/deploy.yaml"
+export PING_PONG_SERVER_SERVICE_PORT=8443
+if ! curl --fail $SERVER_MANIFEST | envsubst | kubectl apply -n "$NAMESPACE" --context "$SERVER_CTX" -f -; then
+  echo "Error: Server deployment failed" >&2
+  exit 1
+fi
+echo "Server deployment complete"
+
+export PING_PONG_SERVER_SERVICE_HOST=ping-pong-server
+CLIENT_MANIFEST="$COFIDE_DEMOS_BRANCH/workloads/ping-pong/ping-pong-client/deploy.yaml"
+if ! curl --fail $CLIENT_MANIFEST | envsubst | kubectl apply --context "$CLIENT_CTX" -n "$NAMESPACE" -f -; then
+  echo "Error: client deployment failed" >&2
+  exit 1
+fi
+echo "Client deployment complete"
+
+kubectl --context $CLIENT_CTX wait -n $NAMESPACE --for=condition=Available --timeout 60s deployments/ping-pong-client
+kubectl --context $CLIENT_CTX logs -n $NAMESPACE deployments/ping-pong-client -f

--- a/templates/trust-zone-server-rbac.yaml
+++ b/templates/trust-zone-server-rbac.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/trust-zone-server-rbac.yaml
+++ b/templates/trust-zone-server-rbac.yaml
@@ -1,0 +1,49 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spire-server
+  labels:
+    name: spire-server
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: spire
+    meta.helm.sh/release-namespace: spire-mgmt
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-server
+  namespace: spire-server
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: spire
+    meta.helm.sh/release-namespace: spire-mgmt
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-manager
+  namespace: spire-server
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spire-server-configmap-binding
+  namespace: spire-server
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire-server
+roleRef:
+  kind: Role
+  name: configmap-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/templates/trust-zone-server-values.yaml
+++ b/templates/trust-zone-server-values.yaml
@@ -1,0 +1,26 @@
+spire-server:
+  image:
+    registry: ${REGISTRY}
+    repository: ${REPOSITORY}
+    tag: ${TAG}
+  controllerManager:
+    enabled: false
+  extraEnv:
+    - name: DATASTORE
+      value: connect
+    - name: CLUSTER_NAME
+      value: ${CLUSTER_NAME}
+    - name: SPIRE_AGENT_NAMESPACE
+      value: spire-system
+    - name: SPIRE_AGENT_SERVICE_ACCOUNT
+      value: spire-agent
+    - name: TRUST_DOMAIN
+      value: ${TRUST_DOMAIN}
+    - name: COFIDE_CONNECT_URL
+      value: ${CONNECT_URL}
+    - name: COFIDE_CONNECT_TRUST_DOMAIN
+      value: ${CONNECT_TRUST_DOMAIN}
+    - name: COFIDE_CONNECT_BUNDLE_ENDPOINT_URL
+      value: ${CONNECT_BUNDLE_ENDPOINT_URL}
+  federation:
+    enabled: true

--- a/terraform/federated/.terraform.lock.hcl
+++ b/terraform/federated/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cofide/cofide" {
   version     = "0.4.0"
   constraints = "0.4.0"
   hashes = [
+    "h1:8XocHPlHRn5x7eEJg3Ps4IcrG8acwXqlz2JLFG7BH4E=",
     "h1:a1AAE2NKud3yulrDRN95ah+p/x8JBhtPr+CCyoHFqDc=",
     "zh:1962b9d81ca21be70b2c94fe4b02c55c0739c4d09c94103bca2f24e9f1e222c0",
     "zh:3d3189e7594fad1b5ecf110b5c4ec802de9f1328487eec106408cecf0ba70284",

--- a/terraform/federated/.terraform.lock.hcl
+++ b/terraform/federated/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cofide/cofide" {
+  version     = "0.4.0"
+  constraints = "0.4.0"
+  hashes = [
+    "h1:a1AAE2NKud3yulrDRN95ah+p/x8JBhtPr+CCyoHFqDc=",
+    "zh:1962b9d81ca21be70b2c94fe4b02c55c0739c4d09c94103bca2f24e9f1e222c0",
+    "zh:3d3189e7594fad1b5ecf110b5c4ec802de9f1328487eec106408cecf0ba70284",
+    "zh:45cba6a8e8fc1d478311d9d38503ab2547ed9748684faf1ca84466ee10f5405e",
+    "zh:52c074d018a34f92846b3e958d501db3415a0f502b7b59bbdf490e4f700318e2",
+    "zh:6c468e2058c628b2960fecf59088251da715f678c5249f24195b6deca3b12283",
+    "zh:6cdaea74ee0cbc01f52a91cabc85b736fbd11d2e237e525fb1e26b7a2a282ff3",
+    "zh:b306341a9272c3d9d44feb01ad202818c5e6c5b4e225716064f1c9d160ff48a2",
+    "zh:c82d4fb60eada576cff1fd19142a6704afdf0eeea84076c9b32b6eaa764543af",
+    "zh:eb039b8fbcba76bb3c76fe0343e4e8161d6cb8b125ad82809806e3aad4790270",
+  ]
+}

--- a/terraform/federated/main.tf
+++ b/terraform/federated/main.tf
@@ -1,0 +1,88 @@
+resource "cofide_connect_trust_zone" "tz_1" {
+  name         = var.trust_zone_1_name
+  trust_domain = var.trust_domain_1
+}
+
+resource "cofide_connect_cluster" "tz_1" {
+  name               = var.cluster_1_name
+  trust_zone_id      = cofide_connect_trust_zone.tz_1.id
+  org_id             = cofide_connect_trust_zone.tz_1.org_id
+  profile            = "kubernetes"
+  kubernetes_context = var.cluster_1_kubernetes_context
+  extra_helm_values  = var.cluster_1_extra_helm_values != "" ? file(var.cluster_1_extra_helm_values) : null
+
+  trust_provider = {
+    kind = "kubernetes"
+  }
+
+  external_server = false
+}
+
+resource "cofide_connect_trust_zone" "tz_2" {
+  name         = var.trust_zone_2_name
+  trust_domain = var.trust_domain_2
+}
+
+resource "cofide_connect_cluster" "tz_2" {
+  name               = var.cluster_2_name
+  trust_zone_id      = cofide_connect_trust_zone.tz_2.id
+  org_id             = cofide_connect_trust_zone.tz_2.org_id
+  profile            = "kubernetes"
+  kubernetes_context = var.cluster_2_kubernetes_context
+  extra_helm_values  = var.cluster_2_extra_helm_values != "" ? file(var.cluster_2_extra_helm_values) : null
+
+  trust_provider = {
+    kind = "kubernetes"
+  }
+
+  external_server = false
+}
+
+resource "cofide_connect_federation" "tz_1" {
+  org_id               = cofide_connect_trust_zone.tz_1.org_id
+  trust_zone_id        = cofide_connect_trust_zone.tz_1.id
+  remote_trust_zone_id = cofide_connect_trust_zone.tz_2.id
+}
+
+resource "cofide_connect_federation" "tz_2" {
+  org_id               = cofide_connect_trust_zone.tz_2.org_id
+  trust_zone_id        = cofide_connect_trust_zone.tz_2.id
+  remote_trust_zone_id = cofide_connect_trust_zone.tz_1.id
+}
+
+resource "cofide_connect_attestation_policy" "namespace" {
+  name   = var.attestation_policy_name
+  org_id = cofide_connect_trust_zone.tz_1.org_id
+
+  kubernetes = {
+    namespace_selector = {
+      match_labels = {
+        "kubernetes.io/metadata.name" = var.attestation_policy_namespace
+      }
+    }
+  }
+}
+
+resource "cofide_connect_ap_binding" "tz_1_namespace" {
+  org_id        = cofide_connect_trust_zone.tz_1.org_id
+  trust_zone_id = cofide_connect_trust_zone.tz_1.id
+  policy_id     = cofide_connect_attestation_policy.namespace.id
+
+  federations = [
+    {
+      trust_zone_id = cofide_connect_trust_zone.tz_2.id
+    }
+  ]
+}
+
+resource "cofide_connect_ap_binding" "tz_2_namespace" {
+  org_id        = cofide_connect_trust_zone.tz_2.org_id
+  trust_zone_id = cofide_connect_trust_zone.tz_2.id
+  policy_id     = cofide_connect_attestation_policy.namespace.id
+
+  federations = [
+    {
+      trust_zone_id = cofide_connect_trust_zone.tz_1.id
+    }
+  ]
+}

--- a/terraform/federated/variables.tf
+++ b/terraform/federated/variables.tf
@@ -1,0 +1,59 @@
+variable "trust_zone_1_name" {
+  type        = string
+  description = "The name of trust zone 1."
+}
+
+variable "trust_domain_1" {
+  type        = string
+  description = "The trust domain associated with trust zone 1."
+}
+
+variable "cluster_1_name" {
+  type        = string
+  description = "The name of the cluster associated with trust zone 1."
+}
+
+variable "cluster_1_kubernetes_context" {
+  type        = string
+  description = "The Kubernetes context for the cluster associated with trust zone 1."
+}
+
+variable "cluster_1_extra_helm_values" {
+  type        = string
+  description = "The extra helm values for the cluster associated with trust zone 1."
+}
+
+variable "attestation_policy_name" {
+  type        = string
+  description = "The name of the namespace attestation policy."
+}
+
+variable "attestation_policy_namespace" {
+  type        = string
+  description = "The namespace to associate with the namespace attestation policy."
+}
+
+variable "trust_zone_2_name" {
+  type        = string
+  description = "The name of trust zone 2."
+}
+
+variable "trust_domain_2" {
+  type        = string
+  description = "The trust domain associated with trust zone 2."
+}
+
+variable "cluster_2_name" {
+  type        = string
+  description = "The name of the cluster associated with trust zone 2."
+}
+
+variable "cluster_2_kubernetes_context" {
+  type        = string
+  description = "The Kubernetes context for the cluster associated with trust zone 2."
+}
+
+variable "cluster_2_extra_helm_values" {
+  type        = string
+  description = "The extra helm values for the cluster associated with trust zone 2."
+}

--- a/terraform/federated/versions.tf
+++ b/terraform/federated/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    cofide = {
+      source  = "cofide/cofide"
+      version = "0.4.0"
+    }
+  }
+}
+
+provider "cofide" {}

--- a/terraform/single-trust-zone/.terraform.lock.hcl
+++ b/terraform/single-trust-zone/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cofide/cofide" {
   version     = "0.4.0"
   constraints = "0.4.0"
   hashes = [
+    "h1:8XocHPlHRn5x7eEJg3Ps4IcrG8acwXqlz2JLFG7BH4E=",
     "h1:a1AAE2NKud3yulrDRN95ah+p/x8JBhtPr+CCyoHFqDc=",
     "zh:1962b9d81ca21be70b2c94fe4b02c55c0739c4d09c94103bca2f24e9f1e222c0",
     "zh:3d3189e7594fad1b5ecf110b5c4ec802de9f1328487eec106408cecf0ba70284",

--- a/terraform/single-trust-zone/.terraform.lock.hcl
+++ b/terraform/single-trust-zone/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cofide/cofide" {
+  version     = "0.4.0"
+  constraints = "0.4.0"
+  hashes = [
+    "h1:a1AAE2NKud3yulrDRN95ah+p/x8JBhtPr+CCyoHFqDc=",
+    "zh:1962b9d81ca21be70b2c94fe4b02c55c0739c4d09c94103bca2f24e9f1e222c0",
+    "zh:3d3189e7594fad1b5ecf110b5c4ec802de9f1328487eec106408cecf0ba70284",
+    "zh:45cba6a8e8fc1d478311d9d38503ab2547ed9748684faf1ca84466ee10f5405e",
+    "zh:52c074d018a34f92846b3e958d501db3415a0f502b7b59bbdf490e4f700318e2",
+    "zh:6c468e2058c628b2960fecf59088251da715f678c5249f24195b6deca3b12283",
+    "zh:6cdaea74ee0cbc01f52a91cabc85b736fbd11d2e237e525fb1e26b7a2a282ff3",
+    "zh:b306341a9272c3d9d44feb01ad202818c5e6c5b4e225716064f1c9d160ff48a2",
+    "zh:c82d4fb60eada576cff1fd19142a6704afdf0eeea84076c9b32b6eaa764543af",
+    "zh:eb039b8fbcba76bb3c76fe0343e4e8161d6cb8b125ad82809806e3aad4790270",
+  ]
+}

--- a/terraform/single-trust-zone/main.tf
+++ b/terraform/single-trust-zone/main.tf
@@ -1,0 +1,37 @@
+resource "cofide_connect_trust_zone" "this" {
+  name         = var.trust_zone_name
+  trust_domain = var.trust_domain
+}
+
+resource "cofide_connect_cluster" "this" {
+  name               = var.cluster_name
+  trust_zone_id      = cofide_connect_trust_zone.this.id
+  org_id             = cofide_connect_trust_zone.this.org_id
+  profile            = "kubernetes"
+  kubernetes_context = var.cluster_kubernetes_context
+
+  trust_provider = {
+    kind = "kubernetes"
+  }
+
+  external_server = false
+}
+
+resource "cofide_connect_attestation_policy" "this" {
+  name   = var.attestation_policy_name
+  org_id = cofide_connect_trust_zone.this.org_id
+
+  kubernetes = {
+    namespace_selector = {
+      match_labels = {
+        "kubernetes.io/metadata.name" = var.attestation_policy_namespace
+      }
+    }
+  }
+}
+
+resource "cofide_connect_ap_binding" "this" {
+  org_id        = cofide_connect_trust_zone.this.org_id
+  trust_zone_id = cofide_connect_trust_zone.this.id
+  policy_id     = cofide_connect_attestation_policy.this.id
+}

--- a/terraform/single-trust-zone/variables.tf
+++ b/terraform/single-trust-zone/variables.tf
@@ -5,7 +5,7 @@ variable "trust_zone_name" {
 
 variable "trust_domain" {
   type        = string
-  description = "The trust domain associated with the left trust zone."
+  description = "The trust domain associated with the trust zone."
 }
 
 variable "cluster_name" {

--- a/terraform/single-trust-zone/variables.tf
+++ b/terraform/single-trust-zone/variables.tf
@@ -1,0 +1,29 @@
+variable "trust_zone_name" {
+  type        = string
+  description = "The name of the trust zone."
+}
+
+variable "trust_domain" {
+  type        = string
+  description = "The trust domain associated with the left trust zone."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster associated with the trust zone."
+}
+
+variable "cluster_kubernetes_context" {
+  type        = string
+  description = "The Kubernetes context for the cluster associated with the trust zone."
+}
+
+variable "attestation_policy_name" {
+  type        = string
+  description = "The name of the namespace attestation policy."
+}
+
+variable "attestation_policy_namespace" {
+  type        = string
+  description = "The namespace to associate with the namespace attestation policy."
+}

--- a/terraform/single-trust-zone/versions.tf
+++ b/terraform/single-trust-zone/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    cofide = {
+      source  = "cofide/cofide"
+      version = "0.4.0"
+    }
+  }
+}
+
+provider "cofide" {}


### PR DESCRIPTION
### Summary
- This PR adds an additional federation example which utilises the `cofide-trust-zone-server`, with deployment driven by `cofidectl` and `terraform-provider-cofide`.
- These changes have been tested against local and remote instances of `connect`:
```
./federated-cofidectl-tf.sh
...

2025/05/28 12:29:03 INFO ping...
2025/05/28 12:29:03 INFO ...pong
2025/05/28 12:29:08 INFO ping...
2025/05/28 12:29:08 INFO ...pong
2025/05/28 12:29:13 INFO ping...
2025/05/28 12:29:13 INFO ...pong
```