### PR TITLE
Multiple fixes to control plane reference

### DIFF
--- a/control-plane/deployment/aws/README.md
+++ b/control-plane/deployment/aws/README.md
@@ -104,6 +104,12 @@ If you already have a VPC, EKS cluster, RDS PostgreSQL instance, and DNS zone, t
 3. **[Connect infrastructure](infra/stack/connect/README.md)** — S3, CloudFront, Connect IAM role, PostgreSQL database and role (`infra/stack/connect/`)
 4. **[Connect API and Connect UI](k8s/connect/README.md)** — Connect API and Connect UI Helm releases and certificates (`k8s/connect/`)
 
+Once all four steps are complete, run `print-cofidectl-config.sh` to print the `cofidectl connect init` command with all values filled in:
+
+```sh
+./print-cofidectl-config.sh
+```
+
 cert-manager (with a Route53 DNS01 ClusterIssuer), ExternalDNS, and the AWS Load Balancer Controller must be running on the cluster before step 2. If not already installed, deploy them first — see [`k8s/controllers/README.md`](k8s/controllers/README.md).
 
 Each Terraform unit reads resource IDs from other units in the stack by default. Supply your existing resource IDs in each unit's `common.local.hcl` — see [`infra/stack/README.md`](infra/stack/README.md) for the values to set.

--- a/control-plane/deployment/aws/README.md
+++ b/control-plane/deployment/aws/README.md
@@ -110,6 +110,8 @@ Once all four steps are complete, run `print-cofidectl-config.sh` to print the `
 ./print-cofidectl-config.sh
 ```
 
+then run the printed command to initialise your local cofidectl.
+
 cert-manager (with a Route53 DNS01 ClusterIssuer), ExternalDNS, and the AWS Load Balancer Controller must be running on the cluster before step 2. If not already installed, deploy them first — see [`k8s/controllers/README.md`](k8s/controllers/README.md).
 
 Each Terraform unit reads resource IDs from other units in the stack by default. Supply your existing resource IDs in each unit's `common.local.hcl` — see [`infra/stack/README.md`](infra/stack/README.md) for the values to set.

--- a/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/README.md
+++ b/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/README.md
@@ -32,17 +32,22 @@ No modules.
 | [aws_acm_certificate_validation.bundle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_cloudfront_distribution.bundle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_origin_access_control.bundle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_kms_key_policy.bundle_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_route53_record.acm_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.bundle_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.bundle_aaaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket_policy.bundle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_object.not_found](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bundle_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.bundle_bucket_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | ARN of the trust bundle S3 bucket. Used to scope the CloudFront OAC bucket policy. | `string` | n/a | yes |
+| <a name="input_bucket_kms_key_arn"></a> [bucket\_kms\_key\_arn](#input\_bucket\_kms\_key\_arn) | ARN of the KMS key used to encrypt the trust bundle bucket. When set, a key policy is created granting the CloudFront distribution kms:Decrypt so it can serve encrypted objects. | `string` | `null` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the trust bundle S3 bucket. Used as the CloudFront OAC name and in the bucket policy. | `string` | n/a | yes |
 | <a name="input_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#input\_bucket\_regional\_domain\_name) | Regional domain name of the trust bundle S3 bucket. Used as the CloudFront origin domain. | `string` | n/a | yes |
 | <a name="input_bundle_domain"></a> [bundle\_domain](#input\_bundle\_domain) | Fully qualified domain name for the trust bundle CloudFront distribution (e.g. bundles.connect.example.com). | `string` | n/a | yes |

--- a/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/main.tf
+++ b/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/main.tf
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "bundle_bucket_kms" {
 
   statement {
     sid       = "AllowCloudFrontDecrypt"
-    actions   = ["kms:Decrypt", "kms:GenerateDataKey*"]
+    actions   = ["kms:Decrypt"]
     resources = ["*"]
 
     principals {

--- a/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/main.tf
+++ b/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/main.tf
@@ -44,6 +44,53 @@ resource "aws_acm_certificate_validation" "bundle" {
   validation_record_fqdns = [for record in aws_route53_record.acm_validation : record.fqdn]
 }
 
+# --- KMS key policy ---
+
+data "aws_caller_identity" "current" {}
+
+# CloudFront's OAC signs requests to S3 as cloudfront.amazonaws.com. When the
+# bucket uses SSE-KMS, S3 needs to call KMS to decrypt the data key on behalf of
+# the requester, so the KMS key policy must explicitly allow the CloudFront service
+# principal. Without this, S3 returns 403 to CloudFront even though the OAC bucket
+# policy grants s3:GetObject.
+data "aws_iam_policy_document" "bundle_bucket_kms" {
+  count = var.bucket_kms_key_arn != null ? 1 : 0
+
+  statement {
+    sid       = "EnableRootAccountAccess"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "AllowCloudFrontDecrypt"
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey*"]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudfront_distribution.bundle.arn]
+    }
+  }
+}
+
+resource "aws_kms_key_policy" "bundle_bucket" {
+  count  = var.bucket_kms_key_arn != null ? 1 : 0
+  key_id = var.bucket_kms_key_arn
+  policy = data.aws_iam_policy_document.bundle_bucket_kms[0].json
+}
+
 # --- CloudFront ---
 
 resource "aws_cloudfront_origin_access_control" "bundle" {
@@ -75,6 +122,13 @@ data "aws_iam_policy_document" "bundle_bucket" {
 resource "aws_s3_bucket_policy" "bundle" {
   bucket = var.bucket_name
   policy = data.aws_iam_policy_document.bundle_bucket.json
+}
+
+resource "aws_s3_object" "not_found" {
+  bucket       = var.bucket_name
+  key          = "404.html"
+  content      = "Not Found"
+  content_type = "text/plain"
 }
 
 resource "aws_cloudfront_distribution" "bundle" {
@@ -115,9 +169,8 @@ resource "aws_cloudfront_distribution" "bundle" {
   custom_error_response {
     # S3 returns 403 (not 404) for missing objects in private buckets to avoid
     # revealing whether keys exist. Map to 404 so callers get a meaningful response.
-    # response_page_path is required alongside response_code by the CloudFront API;
-    # CloudFront falls back to its built-in error page when the path doesn't exist,
-    # which is acceptable since bundle clients only check the status code.
+    # /404.html is created as an aws_s3_object so CloudFront can serve the error page;
+    # if CloudFront cannot fetch the error page it falls back to the raw S3 response.
     error_code            = 403
     response_code         = 404
     response_page_path    = "/404.html"

--- a/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/variables.tf
+++ b/control-plane/deployment/aws/infra/modules/connect/bundle-distribution/variables.tf
@@ -23,6 +23,12 @@ variable "bucket_regional_domain_name" {
   description = "Regional domain name of the trust bundle S3 bucket. Used as the CloudFront origin domain."
 }
 
+variable "bucket_kms_key_arn" {
+  type        = string
+  description = "ARN of the KMS key used to encrypt the trust bundle bucket. When set, a key policy is created granting the CloudFront distribution kms:Decrypt so it can serve encrypted objects."
+  default     = null
+}
+
 variable "price_class" {
   type        = string
   description = "CloudFront price class. PriceClass_100 covers US and Europe only (lowest cost); PriceClass_200 adds more regions; PriceClass_All covers all edge locations."

--- a/control-plane/deployment/aws/infra/modules/eks-cluster/README.md
+++ b/control-plane/deployment/aws/infra/modules/eks-cluster/README.md
@@ -96,6 +96,7 @@ No modules.
 | <a name="output_cluster_endpoint_hostname"></a> [cluster\_endpoint\_hostname](#output\_cluster\_endpoint\_hostname) | EKS API server hostname (without https://) — used as the SSM port forwarding target host |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the EKS cluster |
 | <a name="output_node_security_group_id"></a> [node\_security\_group\_id](#output\_node\_security\_group\_id) | ID of the EKS worker node security group. |
+| <a name="output_oidc_issuer_url"></a> [oidc\_issuer\_url](#output\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (e.g. https://oidc.eks.<region>.amazonaws.com/id/<id>). |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | ARN of the IAM OIDC provider for the cluster. Non-null only when enable\_irsa is true. |
 | <a name="output_region"></a> [region](#output\_region) | AWS region in which the EKS cluster is deployed |
 <!-- END_TF_DOCS -->

--- a/control-plane/deployment/aws/infra/modules/eks-cluster/outputs.tf
+++ b/control-plane/deployment/aws/infra/modules/eks-cluster/outputs.tf
@@ -22,3 +22,8 @@ output "oidc_provider_arn" {
   description = "ARN of the IAM OIDC provider for the cluster. Non-null only when enable_irsa is true."
   value       = var.enable_irsa ? aws_iam_openid_connect_provider.eks[0].arn : null
 }
+
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL for the EKS cluster (e.g. https://oidc.eks.<region>.amazonaws.com/id/<id>)."
+  value       = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}

--- a/control-plane/deployment/aws/infra/stack/README.md
+++ b/control-plane/deployment/aws/infra/stack/README.md
@@ -112,7 +112,7 @@ If your DNS is managed outside Route53, skip `connect/bundle-distribution/` enti
 ```hcl
 locals {
   spire_oidc_domain = "oidc-discovery.example.com"  # must match the SPIRE Helm values
-  spiffe_id         = "spiffe://<trust-domain>/ns/connect/sa/connect-api"
+  spiffe_id         = "spiffe://<trust-domain>/ns/connect/sa/cofide-connect-api"
   db_resource_id    = "db-XXXXXXXXXXXXXXXXXXXX"  # only if bringing your own RDS
 }
 ```

--- a/control-plane/deployment/aws/infra/stack/connect/README.md
+++ b/control-plane/deployment/aws/infra/stack/connect/README.md
@@ -52,7 +52,7 @@ cp common.local.hcl.example common.local.hcl
 terragrunt apply
 ```
 
-`spire_oidc_domain` is the fully-qualified domain of the SPIRE OIDC discovery endpoint (e.g. `oidc-discovery.example.com`). `spiffe_id` is the SPIFFE ID of the Connect API workload (e.g. `spiffe://<trust-domain>/ns/connect/sa/connect-api`).
+`spire_oidc_domain` is the fully-qualified domain of the SPIRE OIDC discovery endpoint (e.g. `oidc-discovery.example.com`). `spiffe_id` is the SPIFFE ID of the Connect API workload (e.g. `spiffe://<trust-domain>/ns/connect/sa/cofide-connect-api`).
 
 ## Alternative trust bundle exposure
 

--- a/control-plane/deployment/aws/infra/stack/connect/bundle-distribution/common.local.hcl.example
+++ b/control-plane/deployment/aws/infra/stack/connect/bundle-distribution/common.local.hcl.example
@@ -18,4 +18,5 @@ locals {
   # bucket_name                  = "my-org-connect-bundles"
   # bucket_arn                   = "arn:aws:s3:::my-org-connect-bundles"
   # bucket_regional_domain_name  = "my-org-connect-bundles.s3.eu-west-2.amazonaws.com"
+  # bucket_kms_key_arn           = "arn:aws:kms:eu-west-2:123456789012:key/mrk-..."
 }

--- a/control-plane/deployment/aws/infra/stack/connect/bundle-distribution/terragrunt.hcl
+++ b/control-plane/deployment/aws/infra/stack/connect/bundle-distribution/terragrunt.hcl
@@ -20,6 +20,7 @@ dependency "bundle_bucket" {
     bucket_name                 = "mock-connect-bundles"
     bucket_arn                  = "arn:aws:s3:::mock-connect-bundles"
     bucket_regional_domain_name = "mock-connect-bundles.s3.eu-west-2.amazonaws.com"
+    kms_key_arn                 = "arn:aws:kms:eu-west-2:000000000000:key/mock-kms-key-id"
   }
 }
 
@@ -37,6 +38,7 @@ locals {
   user_bucket_name                 = try(local.user_config.bucket_name, null)
   user_bucket_arn                  = try(local.user_config.bucket_arn, null)
   user_bucket_regional_domain_name = try(local.user_config.bucket_regional_domain_name, null)
+  user_bucket_kms_key_arn          = try(local.user_config.bucket_kms_key_arn, null)
 }
 
 terraform {
@@ -51,4 +53,5 @@ inputs = {
   bucket_name                 = local.user_bucket_name != null ? local.user_bucket_name : try(dependency.bundle_bucket.outputs.bucket_name, null)
   bucket_arn                  = local.user_bucket_arn != null ? local.user_bucket_arn : try(dependency.bundle_bucket.outputs.bucket_arn, null)
   bucket_regional_domain_name = local.user_bucket_regional_domain_name != null ? local.user_bucket_regional_domain_name : try(dependency.bundle_bucket.outputs.bucket_regional_domain_name, null)
+  bucket_kms_key_arn          = local.user_bucket_kms_key_arn != null ? local.user_bucket_kms_key_arn : try(dependency.bundle_bucket.outputs.kms_key_arn, null)
 }

--- a/control-plane/deployment/aws/infra/stack/connect/iam-role/common.local.hcl.example
+++ b/control-plane/deployment/aws/infra/stack/connect/iam-role/common.local.hcl.example
@@ -9,7 +9,7 @@ locals {
   # REQUIRED: SPIFFE ID of the Connect API workload.
   # For Kubernetes PSAT attestation the format is:
   #   spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
-  # spiffe_id = "spiffe://connect-reference/ns/connect/sa/connect-api"
+  # spiffe_id = "spiffe://connect-reference/ns/connect/sa/cofide-connect-api"
 
   # Override the IAM role name.
   # role_name = "cofide-connect-control-plane-aws-reference-arch-connect-api"

--- a/control-plane/deployment/aws/k8s/connect/README.md
+++ b/control-plane/deployment/aws/k8s/connect/README.md
@@ -81,8 +81,8 @@ cp values.override.yaml.example values.override.yaml
 If all base infra units (`base/eks-cluster/cluster`, `base/dns`, `base/database/rds-instance`) have been applied via this Terragrunt stack, you can generate `values.local.yaml` automatically instead:
 
 ```sh
-./generate-local-values.sh <idp-issuer> <idp-jwks-uri> <ui-subdomain>
-# e.g: ./generate-local-values.sh https://auth.example.com https://auth.example.com/.well-known/jwks.json app
+./generate-local-values.sh <idp-issuer> <idp-jwks-uri> <ui-subdomain> <psat-audience>
+# e.g: ./generate-local-values.sh https://auth.example.com https://auth.example.com/.well-known/jwks.json app connect
 ```
 
 ## Connect UI

--- a/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
@@ -33,7 +33,7 @@ UI_SUBDOMAIN="$3"
 PSAT_AUDIENCE="$4"
 
 echo "Reading trust domain from deployed spire release..."
-TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt -o json | yq '.global.spire.trustDomain')
+TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -r '.global.spire.trustDomain')
 echo "  trust_domain: ${TRUST_DOMAIN}"
 
 echo "Reading region from base/eks-cluster/cluster..."

--- a/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
@@ -33,7 +33,7 @@ UI_SUBDOMAIN="$3"
 PSAT_AUDIENCE="$4"
 
 echo "Reading trust domain from deployed spire release..."
-TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -r '.global.spire.trustDomain')
+TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -re '.global.spire.trustDomain')
 echo "  trust_domain: ${TRUST_DOMAIN}"
 
 echo "Reading region from base/eks-cluster/cluster..."

--- a/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/generate-local-values.sh
@@ -12,23 +12,25 @@
 #
 # Also requires the spire Helm release to be installed in the spire-mgmt namespace.
 #
-# Usage: ./generate-local-values.sh <idp-issuer> <idp-jwks-uri> <ui-subdomain>
-#   idp-issuer:    Issuer URL of the identity provider (e.g. https://auth.example.com)
-#   idp-jwks-uri:  JWKS URI of the identity provider (e.g. https://auth.example.com/.well-known/jwks.json)
-#   ui-subdomain:  Subdomain the Connect UI is served on (e.g. app); used to set the CORS allowed origin
+# Usage: ./generate-local-values.sh <idp-issuer> <idp-jwks-uri> <ui-subdomain> <psat-audience>
+#   idp-issuer:     Issuer URL of the identity provider (e.g. https://auth.example.com)
+#   idp-jwks-uri:   JWKS URI of the identity provider (e.g. https://auth.example.com/.well-known/jwks.json)
+#   ui-subdomain:   Subdomain the Connect UI is served on (e.g. app); used to set the CORS allowed origin
+#   psat-audience:  Expected audience in PSAT tokens sent by Cofide SPIRE servers when registering
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STACK_DIR="${SCRIPT_DIR}/../../../infra/stack"
 
-if [[ $# -lt 3 ]]; then
-  echo "Usage: $(basename "$0") <idp-issuer> <idp-jwks-uri> <ui-subdomain>"
+if [[ $# -lt 4 ]]; then
+  echo "Usage: $(basename "$0") <idp-issuer> <idp-jwks-uri> <ui-subdomain> <psat-audience>"
   exit 1
 fi
 IDP_ISSUER="$1"
 IDP_JWKS_URI="$2"
 UI_SUBDOMAIN="$3"
+PSAT_AUDIENCE="$4"
 
 echo "Reading trust domain from deployed spire release..."
 TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt -o json | yq '.global.spire.trustDomain')
@@ -86,6 +88,7 @@ connect:
     - "https://${UI_SUBDOMAIN}.${ZONE_NAME}"
   trustDomain: ${TRUST_DOMAIN}
   connectTrustBundleStoreURL: https://${DISTRIBUTION_DOMAIN}
+  connectPSATAudience: ${PSAT_AUDIENCE}
   datastore:
     sqlConnectionString:
       enabled: false

--- a/control-plane/deployment/aws/k8s/connect/connect-api/values.local.yaml.example
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/values.local.yaml.example
@@ -25,6 +25,9 @@ connect:
   # URL the trust bundle store is exposed at.
   # [tf: connect/bundle-distribution: distribution_domain_name] — prefix with https://
   connectTrustBundleStoreURL: https://abc123.cloudfront.net
+  # Expected audience in PSAT tokens sent by Cofide SPIRE servers when registering.
+  # [you]
+  connectPSATAudience: connect
   datastore:
     sqlConnectionString:
       enabled: false

--- a/control-plane/deployment/aws/k8s/connect/connect-api/values.yaml
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/values.yaml
@@ -6,6 +6,9 @@
 
 replicaCount: 2
 
+serviceAccount:
+  name: cofide-connect-api
+
 service:
   port: 443
   annotations:

--- a/control-plane/deployment/aws/k8s/connect/connect-api/versions.yaml
+++ b/control-plane/deployment/aws/k8s/connect/connect-api/versions.yaml
@@ -1,1 +1,1 @@
-chartVersion: 0.17.0
+chartVersion: 0.19.1

--- a/control-plane/deployment/aws/print-cofidectl-config.sh
+++ b/control-plane/deployment/aws/print-cofidectl-config.sh
@@ -26,10 +26,10 @@ echo "Reading bundle distribution domain from connect/bundle-distribution..."
 DIST_DOMAIN=$(terragrunt --working-dir "${STACK_DIR}/connect/bundle-distribution" output -raw distribution_domain_name)
 
 echo "Reading Connect trust domain from deployed spire Helm release..."
-CONNECT_TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -r '.global.spire.trustDomain')
+CONNECT_TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -re '.global.spire.trustDomain')
 
 echo "Reading OAuth client ID from deployed connect-ui Helm release..."
-OAUTH_CLIENT_ID=$(helm get values connect-ui --namespace connect --all -o json | jq -r '.ui.oauth.clientId')
+OAUTH_CLIENT_ID=$(helm get values connect-ui --namespace connect --all -o json | jq -re '.ui.oauth.clientId')
 
 echo ""
 echo "Run the following command to initialise cofidectl:"

--- a/control-plane/deployment/aws/print-cofidectl-config.sh
+++ b/control-plane/deployment/aws/print-cofidectl-config.sh
@@ -26,10 +26,10 @@ echo "Reading bundle distribution domain from connect/bundle-distribution..."
 DIST_DOMAIN=$(terragrunt --working-dir "${STACK_DIR}/connect/bundle-distribution" output -raw distribution_domain_name)
 
 echo "Reading Connect trust domain from deployed spire Helm release..."
-CONNECT_TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt -o json | yq '.global.spire.trustDomain')
+CONNECT_TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt --all -o json | jq -r '.global.spire.trustDomain')
 
 echo "Reading OAuth client ID from deployed connect-ui Helm release..."
-OAUTH_CLIENT_ID=$(helm get values connect-ui --namespace connect -o json | yq '.ui.oauth.clientId')
+OAUTH_CLIENT_ID=$(helm get values connect-ui --namespace connect --all -o json | jq -r '.ui.oauth.clientId')
 
 echo ""
 echo "Run the following command to initialise cofidectl:"

--- a/control-plane/deployment/aws/print-cofidectl-config.sh
+++ b/control-plane/deployment/aws/print-cofidectl-config.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Prints the cofidectl connect init command with values derived from the
+# Connect control plane setup.
+#
+# Requires the following to be in place:
+#   infra/stack/base/dns/                    — provides the Connect URL
+#   infra/stack/connect/bundle-distribution/ — provides the bundle host
+#   spire Helm release in spire-mgmt         — provides the Connect trust domain
+#   connect-ui Helm release in connect       — provides the OAuth client ID
+#
+# kubectl must be configured for the control-plane cluster when this script runs.
+#
+# Usage: ./print-cofidectl-config.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_DIR="${SCRIPT_DIR}/infra/stack"
+
+echo "Reading zone name from base/dns..."
+ZONE_NAME=$(terragrunt --working-dir "${STACK_DIR}/base/dns" output -raw zone_name)
+CONNECT_URL="${ZONE_NAME}:443"
+
+echo "Reading bundle distribution domain from connect/bundle-distribution..."
+DIST_DOMAIN=$(terragrunt --working-dir "${STACK_DIR}/connect/bundle-distribution" output -raw distribution_domain_name)
+
+echo "Reading Connect trust domain from deployed spire Helm release..."
+CONNECT_TRUST_DOMAIN=$(helm get values spire --namespace spire-mgmt -o json | yq '.global.spire.trustDomain')
+
+echo "Reading OAuth client ID from deployed connect-ui Helm release..."
+OAUTH_CLIENT_ID=$(helm get values connect-ui --namespace connect -o json | yq '.ui.oauth.clientId')
+
+echo ""
+echo "Run the following command to initialise cofidectl:"
+echo ""
+echo "  cofidectl connect init \\"
+echo "    --connect-url ${CONNECT_URL} \\"
+echo "    --connect-trust-domain ${CONNECT_TRUST_DOMAIN} \\"
+echo "    --connect-bundle-host ${DIST_DOMAIN} \\"
+echo "    --oauth-client-id ${OAUTH_CLIENT_ID}"


### PR DESCRIPTION
- Allow Cloudfront access to KMS key used to encrypt bucket bundle contents (needs to decrypt contents in order to serve them)
- Add 404 object to bucket
- Expose cluster OIDC issuer from EKS cluster module (used in subsequent PR that creates a cluster to host the SPIRE server of a trust zone)
- Amend Connect API service account name to match current hard-coded expectation in Cofide SPIRE (issue to be opened to make the expectation configurable)
- Added PSAT audience to Connect API helm values (must be set, otherwise when a server tries to register it fails - issue to be opened to make this an issue at Connect API startup rather than server registration)
- Bumped Connect API chart version from 0.17.0 to 0.19.1
- Added script to print out values required for `cofidectl connect init` command